### PR TITLE
Clarify README and add placeholder batch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# KardashevOS_Level1
-This project is a ready-to-run full-stack template for AI/web apps. It ships a fast Gateway API that routes requests to modular services (e.g., text generation, alerts, dashboards). Start instantly with included stubs, then plug in your real services. Runs via Docker Compose with simple Windows scripts for start/stop/clean.
+# KardashevOS Level 1
+
+This repository is the starting point for a future full-stack template. At the moment it only contains placeholder batch scripts and basic documentation. The Gateway API and modular services mentioned in earlier drafts have not yet been implemented.
+
+## Windows helper scripts
+
+The following batch files are provided as simple placeholders:
+
+- `start.bat` – prints a message indicating the system is starting.
+- `stop.bat` – prints a message indicating the system is stopping.
+- `clean.bat` – prints a message indicating the environment is being cleaned.
+
+These scripts do not start any real services yet but can be expanded as the project evolves.

--- a/clean.bat
+++ b/clean.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Placeholder clean script for KardashevOS Level 1
+ECHO Cleaning KardashevOS Level 1 environment...

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Placeholder start script for KardashevOS Level 1
+ECHO Starting KardashevOS Level 1...

--- a/stop.bat
+++ b/stop.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Placeholder stop script for KardashevOS Level 1
+ECHO Stopping KardashevOS Level 1...

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+SCRIPT_NAMES = ["start.bat", "stop.bat", "clean.bat"]
+
+def test_batch_scripts_exist():
+    for name in SCRIPT_NAMES:
+        assert Path(name).is_file(), f"{name} script is missing"


### PR DESCRIPTION
## Summary
- Restructure README into readable sections and clarify that the project is a bare skeleton
- Add placeholder Windows `start`, `stop`, and `clean` batch scripts
- Introduce basic pytest checking the presence of batch scripts

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0f7d43fbc8323b740862ebe4bdce0