### PR TITLE
Add marketing research and inbound sales OS scaffold

### DIFF
--- a/src/marketing_os/__init__.py
+++ b/src/marketing_os/__init__.py
@@ -1,0 +1,6 @@
+"""Automated marketing research and inbound sales OS."""
+
+from .models import ChatMessage, MarketContext
+from .orchestrator import MarketingOS
+
+__all__ = ["ChatMessage", "MarketContext", "MarketingOS"]

--- a/src/marketing_os/__main__.py
+++ b/src/marketing_os/__main__.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from .models import ChatMessage, MarketContext
+from .orchestrator import MarketingOS
+
+
+def main() -> None:
+    context = MarketContext(
+        industry="marketing automation",
+        geo="North America",
+        products=("AI marketing OS", "inbound sales CRM"),
+        competitors=("Competitor A", "Competitor B"),
+        goals=("pipeline growth", "higher conversion"),
+    )
+    messages = [
+        ChatMessage(sender="lead-001", content="We need better inbound automation."),
+        ChatMessage(sender="lead-002", content="Can you help with segmentation?"),
+    ]
+    os = MarketingOS()
+    report = os.run_cycle(context=context, messages=messages)
+
+    print(report.summary())
+    print("\nSample campaigns:")
+    for campaign in report.campaigns[:3]:
+        print(f"- {campaign.channel}: {campaign.message} ({campaign.call_to_action})")
+    print("\nAppointments:")
+    for appointment in report.appointments:
+        date = appointment.scheduled_for.strftime("%Y-%m-%d %H:%M")
+        print(f"- {appointment.lead_id}: {appointment.topic} on {date}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/marketing_os/chatbot.py
+++ b/src/marketing_os/chatbot.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .models import ChatMessage, ChatResponse, Segment
+
+
+class ChatbotAgent:
+    def respond(self, messages: Sequence[ChatMessage], segments: Sequence[Segment]) -> list[ChatResponse]:
+        responses: list[ChatResponse] = []
+        segment_names = ", ".join(segment.name for segment in segments[:2])
+        for message in messages:
+            responses.append(
+                ChatResponse(
+                    sender="MarketingOS",
+                    content=(
+                        "Thanks for reaching out! We can align you with "
+                        f"{segment_names}. Would you like a 20-minute consult?"
+                    ),
+                    in_response_to=message,
+                )
+            )
+        return responses

--- a/src/marketing_os/content.py
+++ b/src/marketing_os/content.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from .models import Campaign, Segment
+
+
+class ContentAgent:
+    def create_campaigns(self, segments: Iterable[Segment]) -> Sequence[Campaign]:
+        campaigns: list[Campaign] = []
+        for segment in segments:
+            for channel in segment.preferred_channels:
+                campaigns.append(
+                    Campaign(
+                        name=f"{segment.name} - {channel} launch",
+                        segment=segment.name,
+                        channel=channel,
+                        message=(
+                            f"Solve {segment.pains[0]} with automated research and"
+                            " inbound sales workflows."
+                        ),
+                        call_to_action="Book a tailored demo",
+                    )
+                )
+        return campaigns
+
+    def draft_social_posts(self, campaigns: Iterable[Campaign]) -> list[str]:
+        posts: list[str] = []
+        for campaign in campaigns:
+            posts.append(
+                f"[{campaign.channel}] {campaign.message} CTA: {campaign.call_to_action}."
+            )
+        return posts

--- a/src/marketing_os/crm.py
+++ b/src/marketing_os/crm.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime, timedelta
+
+from .models import Appointment, ChatResponse, CRMRecord, Lead
+
+
+class CRMSystem:
+    def __init__(self) -> None:
+        self._records: dict[str, CRMRecord] = {}
+
+    def register_leads(self, leads: Iterable[Lead]) -> list[CRMRecord]:
+        records: list[CRMRecord] = []
+        for lead in leads:
+            record = self._records.get(lead.lead_id)
+            if record is None:
+                record = CRMRecord(lead=lead, status="new")
+                self._records[lead.lead_id] = record
+            records.append(record)
+        return records
+
+    def log_responses(self, responses: Iterable[ChatResponse]) -> None:
+        for response in responses:
+            lead_id = response.in_response_to.sender
+            record = self._records.get(lead_id)
+            if record is None:
+                continue
+            record.add_note(f"Responded: {response.content}")
+
+    def schedule_appointments(self, leads: Iterable[Lead]) -> list[Appointment]:
+        appointments: list[Appointment] = []
+        for lead in leads:
+            appointment = Appointment(
+                lead_id=lead.lead_id,
+                scheduled_for=datetime.utcnow() + timedelta(days=2),
+                topic=f"Discovery for {lead.interest}",
+            )
+            record = self._records.get(lead.lead_id)
+            if record is not None:
+                record.schedule(appointment)
+                record.status = "scheduled"
+            appointments.append(appointment)
+        return appointments
+
+    def record_sale(self, lead_id: str, note: str) -> None:
+        record = self._records.get(lead_id)
+        if record is None:
+            return
+        record.status = "closed-won"
+        record.add_note(note)
+
+    def pipeline_snapshot(self) -> list[CRMRecord]:
+        return list(self._records.values())

--- a/src/marketing_os/models.py
+++ b/src/marketing_os/models.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class MarketInsight:
+    topic: str
+    trend: str
+    pain_points: Sequence[str]
+    gains: Sequence[str]
+    competitors: Sequence[str]
+    target_users: Sequence[str]
+
+
+@dataclass(frozen=True)
+class Segment:
+    name: str
+    description: str
+    pains: Sequence[str]
+    gains: Sequence[str]
+    preferred_channels: Sequence[str]
+
+
+@dataclass(frozen=True)
+class Campaign:
+    name: str
+    segment: str
+    channel: str
+    message: str
+    call_to_action: str
+
+
+@dataclass(frozen=True)
+class Lead:
+    lead_id: str
+    name: str
+    email: str
+    segment: str
+    interest: str
+
+
+@dataclass(frozen=True)
+class Appointment:
+    lead_id: str
+    scheduled_for: datetime
+    topic: str
+
+
+@dataclass
+class CRMRecord:
+    lead: Lead
+    status: str
+    notes: list[str] = field(default_factory=list)
+    appointments: list[Appointment] = field(default_factory=list)
+
+    def add_note(self, note: str) -> None:
+        self.notes.append(note)
+
+    def schedule(self, appointment: Appointment) -> None:
+        self.appointments.append(appointment)
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    sender: str
+    content: str
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass(frozen=True)
+class ChatResponse:
+    sender: str
+    content: str
+    in_response_to: ChatMessage
+
+
+@dataclass(frozen=True)
+class InboundSalesReport:
+    insights: Sequence[MarketInsight]
+    segments: Sequence[Segment]
+    campaigns: Sequence[Campaign]
+    leads: Sequence[Lead]
+    appointments: Sequence[Appointment]
+    responses: Sequence[ChatResponse]
+
+    def summary(self) -> str:
+        return (
+            "Inbound Sales Summary\n"
+            f"Insights: {len(self.insights)}\n"
+            f"Segments: {len(self.segments)}\n"
+            f"Campaigns: {len(self.campaigns)}\n"
+            f"Leads: {len(self.leads)}\n"
+            f"Appointments: {len(self.appointments)}\n"
+            f"Responses: {len(self.responses)}"
+        )
+
+
+@dataclass(frozen=True)
+class MarketContext:
+    industry: str
+    geo: str
+    products: Iterable[str]
+    competitors: Iterable[str]
+    goals: Iterable[str]

--- a/src/marketing_os/orchestrator.py
+++ b/src/marketing_os/orchestrator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .chatbot import ChatbotAgent
+from .content import ContentAgent
+from .crm import CRMSystem
+from .models import (
+    ChatMessage,
+    InboundSalesReport,
+    Lead,
+    MarketContext,
+)
+from .research import MarketResearchAgent
+from .segmentation import SegmentationAgent
+
+
+class MarketingOS:
+    def __init__(self) -> None:
+        self.research_agent = MarketResearchAgent()
+        self.segmentation_agent = SegmentationAgent()
+        self.content_agent = ContentAgent()
+        self.chatbot_agent = ChatbotAgent()
+        self.crm = CRMSystem()
+
+    def run_cycle(self, context: MarketContext, messages: Sequence[ChatMessage]) -> InboundSalesReport:
+        insights = self.research_agent.analyze(context)
+        segments = self.segmentation_agent.build_segments(insights)
+        campaigns = self.content_agent.create_campaigns(segments)
+        responses = self.chatbot_agent.respond(messages, segments)
+
+        leads = self._qualify_leads(messages, segments)
+        self.crm.register_leads(leads)
+        self.crm.log_responses(responses)
+        appointments = self.crm.schedule_appointments(leads)
+
+        return InboundSalesReport(
+            insights=insights,
+            segments=segments,
+            campaigns=campaigns,
+            leads=leads,
+            appointments=appointments,
+            responses=responses,
+        )
+
+    def _qualify_leads(self, messages: Sequence[ChatMessage], segments) -> list[Lead]:
+        leads: list[Lead] = []
+        segment_name = segments[0].name if segments else "General"
+        for message in messages:
+            leads.append(
+                Lead(
+                    lead_id=message.sender,
+                    name=message.sender,
+                    email=f"{message.sender}@example.com",
+                    segment=segment_name,
+                    interest="automated inbound sales",
+                )
+            )
+        return leads

--- a/src/marketing_os/research.py
+++ b/src/marketing_os/research.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from .models import MarketContext, MarketInsight
+
+
+class MarketResearchAgent:
+    def analyze(self, context: MarketContext) -> Sequence[MarketInsight]:
+        insights: list[MarketInsight] = []
+        for product in context.products:
+            insights.append(
+                MarketInsight(
+                    topic=f"{context.industry} demand for {product}",
+                    trend="steady growth",
+                    pain_points=(
+                        "slow onboarding",
+                        "manual reporting",
+                        "unclear ROI",
+                    ),
+                    gains=("automation", "clear analytics", "faster pipeline"),
+                    competitors=tuple(context.competitors),
+                    target_users=(
+                        f"{context.geo} revenue teams",
+                        f"{context.geo} marketing leaders",
+                    ),
+                )
+            )
+        return insights
+
+    def summarize_pains(self, insights: Iterable[MarketInsight]) -> list[str]:
+        pains: list[str] = []
+        for insight in insights:
+            pains.extend(insight.pain_points)
+        return sorted(set(pains))
+
+    def summarize_gains(self, insights: Iterable[MarketInsight]) -> list[str]:
+        gains: list[str] = []
+        for insight in insights:
+            gains.extend(insight.gains)
+        return sorted(set(gains))

--- a/src/marketing_os/segmentation.py
+++ b/src/marketing_os/segmentation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from .models import MarketInsight, Segment
+
+
+class SegmentationAgent:
+    def build_segments(self, insights: Iterable[MarketInsight]) -> Sequence[Segment]:
+        segments: list[Segment] = []
+        for insight in insights:
+            segments.append(
+                Segment(
+                    name=f"{insight.topic} - Growth Teams",
+                    description="Revenue teams seeking predictable pipeline and fast activation.",
+                    pains=insight.pain_points,
+                    gains=insight.gains,
+                    preferred_channels=("email", "linkedin", "webinars"),
+                )
+            )
+            segments.append(
+                Segment(
+                    name=f"{insight.topic} - Operations",
+                    description="Operations leaders prioritizing automation and reporting clarity.",
+                    pains=(
+                        "data silos",
+                        "manual workflows",
+                        "slow handoffs",
+                    ),
+                    gains=("automation", "fewer errors", "visibility"),
+                    preferred_channels=("slack", "events", "whitepapers"),
+                )
+            )
+        return segments


### PR DESCRIPTION
### Motivation
- Provide a modular scaffold for an automated marketing research and inbound sales system to generate insights, segments, campaigns, chatbot responses, and CRM records. 
- Enable a single orchestration layer that runs a full cycle from market context analysis to lead qualification and appointment scheduling. 
- Ship reusable data models for insights, segments, campaigns, leads, appointments, chat messages/responses, and reports. 

### Description
- Add `src/marketing_os/models.py` to define `MarketInsight`, `Segment`, `Campaign`, `Lead`, `Appointment`, `CRMRecord`, `ChatMessage`, `ChatResponse`, `InboundSalesReport`, and `MarketContext`. 
- Implement `MarketResearchAgent`, `SegmentationAgent`, `ContentAgent`, `ChatbotAgent`, and `CRMSystem` in `research.py`, `segmentation.py`, `content.py`, `chatbot.py`, and `crm.py` respectively, each providing core behaviors like `analyze`, `build_segments`, `create_campaigns`, `respond`, and `register_leads`/`schedule_appointments`. 
- Add `orchestrator.py` with the `MarketingOS` class that composes agents and exposes `run_cycle` and `_qualify_leads` to produce an `InboundSalesReport`. 
- Include a runnable demo entrypoint in `__main__.py` and package exports in `__init__.py` to exercise `MarketingOS` with a sample `MarketContext` and `ChatMessage`s. 

### Testing
- No automated tests were executed as part of this change. 
- Basic manual sanity exercised via the included demo entrypoint which prints `InboundSalesReport.summary()` (not run in CI). 
- Git status and commit operations were performed successfully during the rollout. 
- No unit tests or integration tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949997afe9083238a7b044faa57cefe)